### PR TITLE
remove reporter from JIRA POST

### DIFF
--- a/chrome_ext.js
+++ b/chrome_ext.js
@@ -223,9 +223,6 @@ function createTicket(jiraInfo) {
 			},
 			"assignee": {
 				"name": user
-			},
-			"reporter": {
-				"name": "GitHub Integration"
 			}
 		}
 	});


### PR DESCRIPTION
Some users do not have permission to edit the reporter when creating a ticket or the screen does not have a reporter field. Do not send reporter information in the POST (it will default to the Project's setting)
